### PR TITLE
fix regional characters encoding

### DIFF
--- a/script.js
+++ b/script.js
@@ -2,30 +2,48 @@ const button = document.getElementById("new-advice");
 const root = document.documentElement;
 
 // Event listeners
-document.addEventListener("DOMContentLoaded", getAdvice); // for first advice
+document.addEventListener("DOMContentLoaded", getAdvice()); // for first advice
+
 button.addEventListener("click", () => {
-  getAdvice; // for first advice
+  getAdvice();
   randomizeAccentColor();
-}); // for subsequent advices
-button.addEventListener("click", getAdvice); // for subsequent advices
+});
 
 // API function
 function getAdvice() {
-  const API = `https://api.adviceslip.com/advice?=${new Date().getTime()}`;
+  const API = `https://api.adviceslip.com/advice?timestamp=${Date.now()}`;
 
   fetch(API)
     .then((response) => {
       return response.json(); // this will convert response to json
     })
     .then((data) => {
-      const advice = data.slip.advice;
+      const rawAdvice = data.slip.advice;
+      const fixedAdvice = fixDoubleEncodedUTF8(rawAdvice);
       const adviceId = data.slip.id;
-      document.getElementById("advice-text").textContent = advice;
-      document.querySelector("h1").textContent = "ADVICE #".concat(adviceId);
+
+      document.getElementById("advice-text").textContent = fixedAdvice;
+      document.querySelector("h1").textContent = `ADVICE #${adviceId}`;
     })
     .catch((error) => {
       console.error(error);
     });
+}
+
+// UTF-8 misencoding fix
+// note: escape() is deprecated so it shouldn't be used for URI encoding,
+// but were're using it to fix the double encoding that's causing the issue
+// This approach works because:
+// escape() converts the misinterpreted characters into percent-encoded sequences.
+// decodeURIComponent() then decodes these sequences back into the correct characters.
+// decoreURIComponent() alone doesn't fix the issue
+// 
+function fixDoubleEncodedUTF8(str) {
+  try {
+    return decodeURIComponent(escape(str));
+  } catch (e) {
+    return str;
+  }
 }
 
 // Color randomization


### PR DESCRIPTION
Regional characters are coming doubly encoded from the API:

`{"slip": { "id": 76, "advice": "You will always regret the round of J\u00c3\u00a4germeister."}}`

To fix this, we need to re-decode it:

```js
function fixDoubleEncodedUTF8(str) {
  try {
    return decodeURIComponent(escape(str));
  } catch (e) {
    return str;
  }
}
```

1. escape(str)
Converts characters like Ã¤ into a percent-encoded form:

`"JÃ¤germeister" → "J%C3%A4germeister"`

%C3%A4 is the correct UTF-8 byte sequence for ä

2. decodeURIComponent(...)
Converts %C3%A4 back into the proper character ä

`"J%C3%A4germeister" → "Jägermeister"`

![Zrzut ekranu 2025-05-03 095059](https://github.com/user-attachments/assets/a51d77f4-e902-46b8-a5ea-346a49ddba7d)


This PR also fixes some improper function calls.